### PR TITLE
RLCC event page + event details update

### DIFF
--- a/content/events/2025-10-13_meetup.md
+++ b/content/events/2025-10-13_meetup.md
@@ -15,6 +15,10 @@ links = """
 
 ## About
 
-Join us for an open meetup of the live coding community in Rotterdam (the RLCC, Rotterdam Live Coders Community). Participating artists will show their work environments and creative ideas. The event is an informal yet informative open session and anyone from the public is very welcome to participate, you do not need to have previous experience in live coding or software development. The idea is to share, learn and get inspired in dialogue.
+An open meetup of Rotterdam’s live coding community! The participating artists will show their work environments and creative ideas. The event is an informal yet informative open session anyone from the public is very welcome to take part, you do not need to have an experience in live coding or software development. The idea is to share, learn and get inspired.
 
-The collective is a dynamic group that welcomes anyone with curiosity and a will to participate. We will be showing our live coded works on a big screen and speakers, open a dialogue and we hope to see your works as well. And, as is common in live coding meetups, we like to have a “from-scratch” jam session at the end.
+The Rotterdam Live Coders community is a dynamic group that welcomes anyone with curiosity and a will to participate. The session will be hosted by Rotterdam artists Niki Scheijen (Nikilia), Rik Mertens (trem_werk), Seb Pappalardo (eerie_ear), Den Ree (den_ree) and Wouter Lucifer (Gifmenger).
+
+This edition Hannes Buchweiser and Richard van ‘t Hof will show their audio visual work on a big screen, are open for dialogue and hope to see your work. As a special treat, the community will showcase the first experiments of the forthcoming Mirage performance which will shown at V2_ LIVE later this month.
+
+As ever, if time permits, there will be a ‘from scratch’ jam session.

--- a/content/events/2025-10-13_meetup.md
+++ b/content/events/2025-10-13_meetup.md
@@ -15,10 +15,6 @@ links = """
 
 ## About
 
-An open meetup of Rotterdam’s live coding community! The participating artists will show their work environments and creative ideas. The event is an informal yet informative open session anyone from the public is very welcome to take part, you do not need to have an experience in live coding or software development. The idea is to share, learn and get inspired.
+Join us for an open meetup of the live coding community in Rotterdam (the RLCC, Rotterdam Live Coders Community). Participating artists will show their work environments and creative ideas. The event is an informal yet informative open session and anyone from the public is very welcome to participate, you do not need to have previous experience in live coding or software development. The idea is to share, learn and get inspired in dialogue.
 
-The Rotterdam Live Coders community is a dynamic group that welcomes anyone with curiosity and a will to participate. The session will be hosted by Rotterdam artists Niki Scheijen (Nikilia), Rik Mertens (trem_werk), Seb Pappalardo (eerie_ear), Den Ree (den_ree) and Wouter Lucifer (Gifmenger).
-
-This edition Hannes Buchweiser and Richard van ‘t Hof will show their audio visual work on a big screen, are open for dialogue and hope to see your work. As a special treat, the community will showcase the first experiments of the forthcoming Mirage performance which will shown at V2_ LIVE later this month.
-
-As ever, if time permits, there will be a ‘from scratch’ jam session.
+The collective is a dynamic group that welcomes anyone with curiosity and a will to participate. We will be showing our live coded works on a big screen and speakers, open a dialogue and we hope to see your works as well. And, as is common in live coding meetups, we like to have a “from-scratch” jam session at the end.

--- a/content/events/2025-11-03_meetup.md
+++ b/content/events/2025-11-03_meetup.md
@@ -1,0 +1,24 @@
++++
+title       = "NL_CL x RLCC Meetup"
+description = "@V2_lab for the Unstable Media. An open meetup in Rotterdam."
+
+location    = "[V2_Lab for the Unstable Media, Eendrachtsstraat 10 Rotterdam, NL](https://www.openstreetmap.org/node/6766334767)"
+doors       = 2025-11-03T19:00:00+01:00
+start       = 2025-11-03T19:30:00+01:00
+end         = 2025-11-03T22:00:00+01:00
+price       = "Free entrance"
+
+links = """
+  <!-- ### [» Go to eventpage ](https://v2.nl/events/rotterdam-live-coders-community-meetup-2025-iv) -->
+"""
++++
+
+## About
+
+An open meetup of Rotterdam’s live coding community! The participating artists will show their work environments and creative ideas. The event is an informal yet informative open session anyone from the public is very welcome to take part, you do not need to have an experience in live coding or software development. The idea is to share, learn and get inspired.
+
+The Rotterdam Live Coders community is a dynamic group that welcomes anyone with curiosity and a will to participate. The session will be hosted by Rotterdam artists Niki Scheijen (Nikilia), Rik Mertens (trem_werk), Seb Pappalardo (eerie_ear), Den Ree (den_ree) and Wouter Lucifer (Gifmenger).
+
+This edition Hannes Buchweiser and Richard van ‘t Hof will show their audio visual work on a big screen, are open for dialogue and hope to see your work. As a special treat, the community will showcase the first experiments of the forthcoming Mirage performance which will shown at V2_ LIVE later this month.
+
+As ever, if time permits, there will be a ‘from scratch’ jam session.

--- a/content/rlcc/_index.md
+++ b/content/rlcc/_index.md
@@ -1,0 +1,8 @@
++++
+title = "RLCC — Rotterdam Live Coders Community"
+description = "All RLCC meetups and events in one place."
++++
+
+Welcome to the Rotterdam Live Coders Community (RLCC). This page lists all RLCC-related events hosted via NL_CL.
+
+

--- a/layouts/rlcc/list.html
+++ b/layouts/rlcc/list.html
@@ -1,0 +1,30 @@
+{{ define "main" }}
+<div class="event-list-header">
+    <h1>{{ .Page.Title }}</h1>
+</div>
+<br/>
+{{ .Content }}
+
+{{ $events := site.GetPage "/events" }}
+<div class="posts-list">
+{{ with $events }}
+    {{ range sort .Pages ".Params.start" "desc" }}
+        {{ if and (not .Params.private) (in (lower .Title) "rlcc") }}
+            <div class="post">
+                <div class="date">{{ .Params.start.Format "Jan. 2, 2006" }}</div>
+                <h1 class="event-list-title"><a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>
+                {{ .Description }}
+                <div class="event-item-ctas">
+                    {{ with .OutputFormats.Get "calendar" }}
+                    <a class="download-ics-btn" href="{{ .RelPermalink }}">+ Add to calendar</a>
+                    {{ end }}
+                </div>
+            </div>
+        {{ end }}
+    {{ end }}
+{{ end }}
+</div>
+
+{{ end }}
+
+


### PR DESCRIPTION
- added /rlcc page that lists all events with RLCC in the title, to link to during meetups.
- updated description for november meetup